### PR TITLE
fix: stop infinite backend query spam on page load

### DIFF
--- a/TaskPlatformFrontend/src/pages/client/ClientDashboard.jsx
+++ b/TaskPlatformFrontend/src/pages/client/ClientDashboard.jsx
@@ -13,9 +13,9 @@ export const ClientDashboard = () => {
 
   useEffect(() => {
     if (user?.id) {
-          fetchData();
+      fetchData();
     }
-  }, [user]);
+  }, [user?.id]);
 
   const fetchData = () => {
     clientTaskService.getTasksByClientId(user.id).then(response => {

--- a/TaskPlatformFrontend/src/pages/client/TaskMilestonesPage.jsx
+++ b/TaskPlatformFrontend/src/pages/client/TaskMilestonesPage.jsx
@@ -1,4 +1,4 @@
-import React, { useContepxt, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AuthContext } from '../../context/AuthContext';
 import { clientTaskService } from '../../services/taskService';

--- a/TaskPlatformFrontend/src/pages/freelancer/FreelancerDashboard.jsx
+++ b/TaskPlatformFrontend/src/pages/freelancer/FreelancerDashboard.jsx
@@ -14,7 +14,7 @@ export const FreelancerDashboard = () => {
     if (user?.id) {
       fetchStatsTasksAndMilestones();
     }
-  }, [user]);
+  }, [user?.id]);
 
   const fetchStatsTasksAndMilestones = async () => {
     try {


### PR DESCRIPTION
Fixes repeated API calls causing infinite Hibernate SQL execution.

Closes #1
